### PR TITLE
Streaming commands / Communication

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,42 @@ The Scrapy Streaming provides an interface to write spiders using any programmin
 
 Also, we officially provide helper libraries to develop your spiders using Java, JS, and R.
 
+## Quickstart
+
+You can read a quick tutorial about scrapy-streaming at http://gsoc2016.readthedocs.io/en/latest/quickstart.html
+
+## Usage
+
+You can execute an external spider using the ``streaming`` command, as follows:
+
+    scrapy streaming /path/of/executable
+
+and if you need to use extra arguments, add them using the ``-a`` parameter:
+
+    scrapy streaming my_executable -a arg1 -a arg2 -a arg3,arg4
+
+If you want to integrate this spider with a scrapy's project, define it in the ``external.json`` file in the root of the project.
+For example, to add a spider developed in java, and a compiled one, the ``external.json`` can be defined as:
+
+    [
+      {
+        "name": "java_spider",
+        "command": "java",
+        "args": ["/home/user/MySpider"]
+      },
+      {
+        "name": "compiled_spider",
+        "command": "/home/user/my_executable"
+      }
+    ]
+
+and then you can execute them using the ``crawl`` command. Inside the project directory, run:
+
+    scrapy crawl spider_name
+
+in this example, ``spider_name`` can be ``java_spider``, ``compiled_spider``, or the name of a Scrapy's spider.
+
+## Documentation
+
+Documentation is available online at http://gsoc2016.readthedocs.io and in the docs directory.
+(Temp url, this doc is from the development fork)

--- a/scrapy_streaming/commands/crawl.py
+++ b/scrapy_streaming/commands/crawl.py
@@ -1,8 +1,17 @@
 from scrapy.commands.crawl import Command
 
+from scrapy_streaming.external_spiderloader import ExternalSpiderLoader
+
 
 class CrawlCommand(Command):
     """
     Extends the scrapy crawl command, adding the possibility to start a external spider using the crawl command
     """
-    pass
+
+    def run(self, args, opts):
+        try:
+            super(CrawlCommand, self).run(args, opts)
+        except KeyError:
+            spname = args[0]
+
+            ExternalSpiderLoader.from_settings(self.settings).crawl(spname)

--- a/scrapy_streaming/commands/streaming.py
+++ b/scrapy_streaming/commands/streaming.py
@@ -3,6 +3,8 @@ import os
 from scrapy.commands import ScrapyCommand
 from scrapy.exceptions import UsageError
 
+from scrapy_streaming.external_spiderloader import ExternalSpider, ExternalSpiderLoader
+
 
 class StreamingCommand(ScrapyCommand):
     """
@@ -17,6 +19,12 @@ class StreamingCommand(ScrapyCommand):
     def short_desc(self):
         return "Run a external spider using Scrapy Streaming given its path (doesn't require a project)"
 
+    def add_options(self, parser):
+        super(StreamingCommand, self).add_options(parser)
+
+        parser.add_option('-a', '--args', default=[], action='append', metavar="'ARG1,ARG2,...'",
+                          help='set command arguments')
+
     def run(self, args, opts):
         if len(args) != 1:
             raise UsageError()
@@ -24,4 +32,19 @@ class StreamingCommand(ScrapyCommand):
         if not os.path.exists(filename):
             raise UsageError("File not found: %s\n" % filename)
 
-        raise NotImplementedError()
+        arguments = _parse_arguments(opts.args)
+        spider = ExternalSpider('StreamingSpider', filename, arguments)
+        loader = ExternalSpiderLoader.from_settings(self.settings, load_spiders=False)
+
+        loader.crawl(spider)
+
+
+def _parse_arguments(list_of_args):
+    """
+    Receives a list with string arguments and split the string arguments by comma
+    """
+    args = []
+    for arg in list_of_args:
+        args += [argument.strip() for argument in arg.split(',')]
+
+    return args

--- a/scrapy_streaming/commands/streaming.py
+++ b/scrapy_streaming/commands/streaming.py
@@ -28,12 +28,10 @@ class StreamingCommand(ScrapyCommand):
     def run(self, args, opts):
         if len(args) != 1:
             raise UsageError()
-        filename = args[0]
-        if not os.path.exists(filename):
-            raise UsageError("File not found: %s\n" % filename)
+        command = args[0]
 
         arguments = _parse_arguments(opts.args)
-        spider = ExternalSpider('StreamingSpider', filename, arguments)
+        spider = ExternalSpider('StreamingSpider', command, arguments)
         loader = ExternalSpiderLoader.from_settings(self.settings, load_spiders=False)
 
         loader.crawl(spider)

--- a/scrapy_streaming/communication/__init__.py
+++ b/scrapy_streaming/communication/__init__.py
@@ -1,0 +1,3 @@
+from scrapy_streaming.communication.map import CommunicationMap
+from scrapy_streaming.communication.wrappers import *
+

--- a/scrapy_streaming/communication/map.py
+++ b/scrapy_streaming/communication/map.py
@@ -1,0 +1,28 @@
+from scrapy.utils.python import to_bytes
+
+from scrapy_streaming.communication import wrappers
+
+
+class CommunicationMap(object):
+    """
+    Helper class to create the json messages
+    """
+
+    @staticmethod
+    def ready():
+        return wrappers.ReadyMessage.parse()
+
+    @staticmethod
+    def response(resp, request_id=b'parse'):
+        fields = _extract_fields(resp, ['url', 'headers', 'status', 'body', 'meta', 'flags'])
+        fields[b'id'] = to_bytes(request_id)
+
+        return wrappers.ResponseMessage.parse(fields)
+
+
+def _extract_fields(item, fields):
+    data = {}
+    for field in fields:
+        data[to_bytes(field)] = to_bytes(getattr(item, field))
+
+    return data

--- a/scrapy_streaming/communication/map.py
+++ b/scrapy_streaming/communication/map.py
@@ -1,6 +1,6 @@
 import json
 
-from scrapy.utils.python import to_unicode
+from scrapy.utils.python import to_unicode, to_native_str
 
 from scrapy_streaming.communication import wrappers
 from scrapy_streaming.utils import MessageError
@@ -13,13 +13,14 @@ class CommunicationMap(object):
 
     mapping = {
         'spider': wrappers.SpiderMessage,
-        'request': wrappers.RequestMessage
+        'request': wrappers.RequestMessage,
+        'log': wrappers.LogMessage
     }
 
     @staticmethod
     def parse(line):
         try:
-            msg = json.loads(line)
+            msg = json.loads(to_native_str(line))
 
             if not isinstance(msg, dict):
                 raise MessageError('This message is not a json object.')
@@ -54,7 +55,11 @@ class CommunicationMap(object):
 
 
 def _extract_fields(item, fields):
+    """
+    Given a list of fields, generate a dict with key being the name of the field
+     mapping to the serialized item.field value
+    """
     data = {}
     for field in fields:
-        data[field] = json.dumps(getattr(item, field))
+        data[field] = json.loads(json.dumps(getattr(item, field)))
     return data

--- a/scrapy_streaming/communication/map.py
+++ b/scrapy_streaming/communication/map.py
@@ -1,6 +1,9 @@
-from scrapy.utils.python import to_bytes
+import json
+
+from scrapy.utils.python import to_unicode
 
 from scrapy_streaming.communication import wrappers
+from scrapy_streaming.utils import MessageError
 
 
 class CommunicationMap(object):
@@ -8,21 +11,50 @@ class CommunicationMap(object):
     Helper class to create the json messages
     """
 
+    mapping = {
+        'spider': wrappers.SpiderMessage,
+        'request': wrappers.RequestMessage
+    }
+
+    @staticmethod
+    def parse(line):
+        try:
+            msg = json.loads(line)
+
+            if not isinstance(msg, dict):
+                raise MessageError('This message is not a json object.')
+            if 'type' not in msg:
+                raise MessageError('"type" field not provided.')
+
+            msg_type = msg.pop('type')
+            try:
+                return CommunicationMap.mapping[msg_type].from_dict(msg)
+            except KeyError:
+                raise MessageError('%s is not a valid message type.' % msg_type)
+        except ValueError:
+            raise MessageError('Received message is not a valid json.')
+
     @staticmethod
     def ready():
-        return wrappers.ReadyMessage.parse()
+        fields = {'type': 'ready', 'status': 'ready'}
+        return json.dumps(fields)
 
     @staticmethod
-    def response(resp, request_id=b'parse'):
-        fields = _extract_fields(resp, ['url', 'headers', 'status', 'body', 'meta', 'flags'])
-        fields[b'id'] = to_bytes(request_id)
+    def error(message, details):
+        fields = {'type': 'error',
+                  'received_message': to_unicode(message),
+                  'details': to_unicode(details)}
+        return json.dumps(fields)
 
-        return wrappers.ResponseMessage.parse(fields)
+    @staticmethod
+    def response(resp, request_id='parse'):
+        fields = _extract_fields(resp, ['url', 'headers', 'status', 'body', 'meta', 'flags'])
+        fields['id'] = to_unicode(request_id)
+        return json.dumps(fields)
 
 
 def _extract_fields(item, fields):
     data = {}
     for field in fields:
-        data[to_bytes(field)] = to_bytes(getattr(item, field))
-
+        data[field] = json.dumps(getattr(item, field))
     return data

--- a/scrapy_streaming/communication/wrappers.py
+++ b/scrapy_streaming/communication/wrappers.py
@@ -1,5 +1,6 @@
 import six
 
+from scrapy_streaming.spiders import StreamingSpider
 from scrapy_streaming.utils import MessageError, RequiredField
 
 
@@ -7,6 +8,7 @@ class ExternalSpiderMessageWrapper(object):
     validator = {}
 
     def __init__(self, default, fields):
+        self.data = fields
         self.validate(fields)
         self.update(default, fields)
 
@@ -62,8 +64,3 @@ class LogMessage(ExternalSpiderMessageWrapper):
         default = {'message': RequiredField(), 'level': RequiredField()}
 
         super(LogMessage, self).__init__(default, fields)
-
-    def log(self):
-        import logging
-        logging.info(self.message)
-        # FIXME add a real logger

--- a/scrapy_streaming/communication/wrappers.py
+++ b/scrapy_streaming/communication/wrappers.py
@@ -1,63 +1,54 @@
-from scrapy_streaming.utils import WrongMessage
+import six
 
-
-class StreamingMessageWrapper(object):
-    template = b''
-
-    @classmethod
-    def parse(cls, dict_args=None):
-        msg = b''.join([line.strip() for line in cls.template.splitlines()])
-        if dict_args:
-            return msg % dict_args
-        return msg
+from scrapy_streaming.utils import MessageError, RequiredField
 
 
 class ExternalSpiderMessageWrapper(object):
-
     validator = {}
+
+    def __init__(self, default, fields):
+        self.validate(fields)
+        self.update(default, fields)
 
     @classmethod
     def from_dict(cls, data):
-        return cls(**data)
+        return cls(data)
 
-    def validate(self):
-        for field in self.validator:
-            attr = getattr(self, field[0])
-            if not isinstance(attr, field[1]):
-                raise WrongMessage('%s field must be defined as %s, received: %s' %
-                                   (field[0], field[1].__name__, type(attr).__name__))
+    def validate(self, data):
+        validator = self.validator
+        for key, value in data.items():
+            if key not in validator:
+                raise MessageError('Unknown message field: %s' % key)
 
+            if value is not None and not isinstance(value, validator[key]):
+                raise MessageError('%s field must be defined as %s, received: %s' %
+                                   (key, validator[key].__name__, type(value).__name__))
 
-# Scrapy Streaming Messages
-# -------------------------
+    def update(self, default, data):
+        default.update(data)
+        for item, value in default.items():
+            if isinstance(value, RequiredField):
+                raise MessageError('Required field: %s' % item)
+            setattr(self, item, value)
 
-
-class ReadyMessage(StreamingMessageWrapper):
-    template = b'{"type":"status","status":"ready"}'
-
-
-class ResponseMessage(StreamingMessageWrapper):
-    template = b'''
-{
-    "type":"response",
-    "id":'%(id)s',
-    "url":'%(url)s',
-    "headers":%(headers)s,
-    "status":%(status)s,
-    "body":'%(body)s',
-    "meta":%(meta)s,
-    "flags":%(flags)s
-}'''
-
-
-# External Spider Messages
-# ------------------------
 
 class RequestMessage(ExternalSpiderMessageWrapper):
+    validator = {'id': six.text_type, 'url': six.text_type}
 
-    def __init__(self, id, url, method=None, meta=None, body=None, headers=None,
-                       cookies=None, encoding=None, priority=None, dont_filter=None):
-        self.id = id
-        self.url = url
+    def __init__(self, fields):
+        default = {'id': None, 'start_urls': None, 'method': None, 'meta': None,
+                   'body': None, 'headers': None, 'cookies': None, 'encoding': None,
+                   'priority': None, 'dont_filter': None}
 
-        self.validate()
+        super(RequestMessage, self).__init__(default, fields)
+
+
+class SpiderMessage(ExternalSpiderMessageWrapper):
+    validator = {'name': six.text_type, 'start_urls': list,
+                 'allowed_domains': list, 'custom_settings': dict}
+
+    def __init__(self, fields):
+        default = {'name': RequiredField(), 'start_urls': RequiredField(),
+                   'allowed_domains': None, 'custom_settings': None}
+
+        super(SpiderMessage, self).__init__(default, fields)

--- a/scrapy_streaming/communication/wrappers.py
+++ b/scrapy_streaming/communication/wrappers.py
@@ -52,3 +52,18 @@ class SpiderMessage(ExternalSpiderMessageWrapper):
                    'allowed_domains': None, 'custom_settings': None}
 
         super(SpiderMessage, self).__init__(default, fields)
+
+
+class LogMessage(ExternalSpiderMessageWrapper):
+
+    validator = {'message': six.text_type, 'level': six.text_type}
+
+    def __init__(self, fields):
+        default = {'message': RequiredField(), 'level': RequiredField()}
+
+        super(LogMessage, self).__init__(default, fields)
+
+    def log(self):
+        import logging
+        logging.info(self.message)
+        # FIXME add a real logger

--- a/scrapy_streaming/communication/wrappers.py
+++ b/scrapy_streaming/communication/wrappers.py
@@ -1,0 +1,63 @@
+from scrapy_streaming.utils import WrongMessage
+
+
+class StreamingMessageWrapper(object):
+    template = b''
+
+    @classmethod
+    def parse(cls, dict_args=None):
+        msg = b''.join([line.strip() for line in cls.template.splitlines()])
+        if dict_args:
+            return msg % dict_args
+        return msg
+
+
+class ExternalSpiderMessageWrapper(object):
+
+    validator = {}
+
+    @classmethod
+    def from_dict(cls, data):
+        return cls(**data)
+
+    def validate(self):
+        for field in self.validator:
+            attr = getattr(self, field[0])
+            if not isinstance(attr, field[1]):
+                raise WrongMessage('%s field must be defined as %s, received: %s' %
+                                   (field[0], field[1].__name__, type(attr).__name__))
+
+
+# Scrapy Streaming Messages
+# -------------------------
+
+
+class ReadyMessage(StreamingMessageWrapper):
+    template = b'{"type":"status","status":"ready"}'
+
+
+class ResponseMessage(StreamingMessageWrapper):
+    template = b'''
+{
+    "type":"response",
+    "id":'%(id)s',
+    "url":'%(url)s',
+    "headers":%(headers)s,
+    "status":%(status)s,
+    "body":'%(body)s',
+    "meta":%(meta)s,
+    "flags":%(flags)s
+}'''
+
+
+# External Spider Messages
+# ------------------------
+
+class RequestMessage(ExternalSpiderMessageWrapper):
+
+    def __init__(self, id, url, method=None, meta=None, body=None, headers=None,
+                       cookies=None, encoding=None, priority=None, dont_filter=None):
+        self.id = id
+        self.url = url
+
+        self.validate()

--- a/scrapy_streaming/external_spiderloader.py
+++ b/scrapy_streaming/external_spiderloader.py
@@ -69,7 +69,7 @@ class ExternalSpiderLoader(object):
             name_or_spider = self._spiders[name_or_spider]
 
         protocol = ProcessStreamingProtocol()
-        reactor.spawnProcess(protocol, name_or_spider.command, name_or_spider.args)
+        reactor.spawnProcess(protocol, name_or_spider.command, args=[name_or_spider.command] + name_or_spider.args)
         reactor.run()
 
 

--- a/scrapy_streaming/external_spiderloader.py
+++ b/scrapy_streaming/external_spiderloader.py
@@ -1,6 +1,9 @@
 import json
 import os
 
+from twisted.internet import reactor
+
+from scrapy_streaming.process_streaming import ProcessStreamingProtocol
 from scrapy_streaming.utils import get_project_root
 
 
@@ -9,7 +12,7 @@ class ExternalSpider(object):
     Object to represent external spiders defined in ``external.json``.
     """
 
-    def __init__(self, name, command, args=None):
+    def __init__(self, name, command, args=[]):
         if args is not None and not isinstance(args, list):
             raise ValueError("'args' must be defined as an array of strings")
         self.name = name
@@ -26,17 +29,19 @@ class ExternalSpiderLoader(object):
     This class manages external spiders defined in the ``external.json``
     """
 
-    def __init__(self, settings):
-        path = settings.get('EXTERNAL_SPIDERS_PATH', get_project_root())
-        # TODO add EXTERNAL_SPIDERS_PATH in docs
-        path = os.path.abspath(path)
-        self.external = os.path.join(path, 'external.json')
+    def __init__(self, settings, load_spiders=True):
         self._spiders = {}
-        self._fetch_spiders()
+
+        if load_spiders:
+            path = settings.get('EXTERNAL_SPIDERS_PATH', get_project_root())
+            # TODO add EXTERNAL_SPIDERS_PATH in docs
+            path = os.path.abspath(path)
+            self.external = os.path.join(path, 'external.json')
+            self._fetch_spiders()
 
     @classmethod
-    def from_settings(cls, settings):
-        return cls(settings)
+    def from_settings(cls, settings, **kw):
+        return cls(settings, **kw)
 
     def _fetch_spiders(self):
         """
@@ -58,6 +63,14 @@ class ExternalSpiderLoader(object):
         Returns a list with instance of loaded spiders (ExternalSpider objects)
         """
         return list(self._spiders.values())
+
+    def crawl(self, name_or_spider):
+        if not isinstance(name_or_spider, ExternalSpider):
+            name_or_spider = self._spiders[name_or_spider]
+
+        protocol = ProcessStreamingProtocol()
+        reactor.spawnProcess(protocol, name_or_spider.command, name_or_spider.args)
+        reactor.run()
 
 
 def _read_json(path):

--- a/scrapy_streaming/line_receiver.py
+++ b/scrapy_streaming/line_receiver.py
@@ -1,3 +1,4 @@
+from scrapy.utils.python import to_bytes
 from twisted.internet import protocol
 
 
@@ -37,6 +38,7 @@ class LineProcessProtocol(protocol.ProcessProtocol):
         """
         Write the data to the process stdin, adding the new-line delimiter if necessary
         """
+        data = to_bytes(data)
         if not data.endswith(b'\n'):
             data += self.__delimiter
         self.transport.write(data)

--- a/scrapy_streaming/line_receiver.py
+++ b/scrapy_streaming/line_receiver.py
@@ -2,7 +2,7 @@ from scrapy.utils.python import to_bytes
 from twisted.internet import protocol
 
 
-class LineProcessProtocol(protocol.ProcessProtocol):
+class LineProcessProtocol(protocol.ProcessProtocol, object):
     """
     This class extends the twisted ProcessProtocol to split the incoming data in lines.
     The data received by ``outReceived`` if added to an internal buffer, and dispatched by ``lineReceived``

--- a/scrapy_streaming/line_receiver.py
+++ b/scrapy_streaming/line_receiver.py
@@ -1,0 +1,42 @@
+from twisted.internet import protocol
+
+
+class LineProcessProtocol(protocol.ProcessProtocol):
+    """
+    This class extends the twisted ProcessProtocol to split the incoming data in lines.
+    The data received by ``outReceived`` if added to an internal buffer, and dispatched by ``lineReceived``
+    """
+
+    def __init__(self):
+        self.__buffer = b''
+        self.__delimiter = b'\n'
+
+    def outReceived(self, data):
+        """
+        Implement the outReceived method, buffering the incoming data and
+        dispatching line by line in the ``lineReceived`` method.
+        """
+        self.__buffer += data
+
+        lines = self.__buffer.splitlines()
+        if data.endswith(self.__delimiter):
+            self.__buffer = b''
+        else:
+            self.__buffer = lines.pop()
+
+        for line in lines:
+            self.lineReceived(line)
+
+    def lineReceived(self, line):
+        """
+        An entire line received by process stdout. You must implement this method to use this class.
+        """
+        raise NotImplementedError
+
+    def writeLine(self, data):
+        """
+        Write the data to the process stdin, adding the new-line delimiter if necessary
+        """
+        if not data.endswith(b'\n'):
+            data += self.__delimiter
+        self.transport.write(data)

--- a/scrapy_streaming/process_streaming.py
+++ b/scrapy_streaming/process_streaming.py
@@ -1,4 +1,6 @@
-from scrapy_streaming.communication import CommunicationMap
+from twisted.internet import reactor
+
+from scrapy_streaming.communication import CommunicationMap, LogMessage
 from scrapy_streaming.line_receiver import LineProcessProtocol
 from scrapy_streaming.utils import MessageError
 
@@ -15,7 +17,9 @@ class ProcessStreamingProtocol(LineProcessProtocol):
     def lineReceived(self, line):
         try:
             msg = CommunicationMap.parse(line)
-            print(msg)
+
+            if isinstance(msg, LogMessage):
+                msg.log()
         except MessageError as e:
             self.sendError(line, str(e))
 
@@ -23,5 +27,8 @@ class ProcessStreamingProtocol(LineProcessProtocol):
         self.writeLine(CommunicationMap.error(msg, details))
 
     def errReceived(self, data):
-        print('outReceived')
         print(data)
+
+    def processEnded(self, reason):
+        reactor.stop()
+        # FIXME add a valid process listener

--- a/scrapy_streaming/process_streaming.py
+++ b/scrapy_streaming/process_streaming.py
@@ -1,5 +1,6 @@
 from scrapy_streaming.communication import CommunicationMap
 from scrapy_streaming.line_receiver import LineProcessProtocol
+from scrapy_streaming.utils import MessageError
 
 
 class ProcessStreamingProtocol(LineProcessProtocol):
@@ -9,14 +10,17 @@ class ProcessStreamingProtocol(LineProcessProtocol):
     """
 
     def connectionMade(self):
-        print('connectionMade')
-        import sys
-        print(sys.version)
         self.writeLine(CommunicationMap.ready())
 
     def lineReceived(self, line):
-        print('lineReceived')
-        print(line)
+        try:
+            msg = CommunicationMap.parse(line)
+            print(msg)
+        except MessageError as e:
+            self.sendError(line, str(e))
+
+    def sendError(self, msg, details):
+        self.writeLine(CommunicationMap.error(msg, details))
 
     def errReceived(self, data):
         print('outReceived')

--- a/scrapy_streaming/process_streaming.py
+++ b/scrapy_streaming/process_streaming.py
@@ -1,0 +1,23 @@
+from scrapy_streaming.communication import CommunicationMap
+from scrapy_streaming.line_receiver import LineProcessProtocol
+
+
+class ProcessStreamingProtocol(LineProcessProtocol):
+    """
+    This class is responsible for the communication channel between scrapy-streaming and the external spider.
+    All messages are sent/received by this class
+    """
+
+    def connectionMade(self):
+        print('connectionMade')
+        import sys
+        print(sys.version)
+        self.writeLine(CommunicationMap.ready())
+
+    def lineReceived(self, line):
+        print('lineReceived')
+        print(line)
+
+    def errReceived(self, data):
+        print('outReceived')
+        print(data)

--- a/scrapy_streaming/spiders.py
+++ b/scrapy_streaming/spiders.py
@@ -1,5 +1,13 @@
 from scrapy import Spider
+from twisted.internet import defer
 
 
 class StreamingSpider(Spider):
-    pass
+
+    def __init__(self, process, **kwargs):
+        super(StreamingSpider, self).__init__(**kwargs)
+        self.process = process
+        self.stream = defer.Deferred()
+
+    def parse(self, response):
+        return self.stream

--- a/scrapy_streaming/spiders.py
+++ b/scrapy_streaming/spiders.py
@@ -1,0 +1,5 @@
+from scrapy import Spider
+
+
+class StreamingSpider(Spider):
+    pass

--- a/scrapy_streaming/utils.py
+++ b/scrapy_streaming/utils.py
@@ -24,5 +24,9 @@ def dict_serialize(dict_obj, enc=None):
     return to_bytes(json.dumps(dict_obj), enc)
 
 
-class WrongMessage(Exception):
+class MessageError(Exception):
+    pass
+
+
+class RequiredField(object):
     pass

--- a/scrapy_streaming/utils.py
+++ b/scrapy_streaming/utils.py
@@ -1,7 +1,9 @@
+import json
 import os
 
 from scrapy.utils.conf import closest_scrapy_cfg
 from scrapy.utils.project import inside_project
+from scrapy.utils.python import to_bytes
 
 
 def get_project_root():
@@ -13,3 +15,14 @@ def get_project_root():
     if inside_project():
         return os.path.dirname(closest_scrapy_cfg())
     raise Exception(os.getcwd(), " does not belong to a Scrapy project")
+
+
+def dict_serialize(dict_obj, enc=None):
+    """
+    Serialize a dict object and converts it to bytes
+    """
+    return to_bytes(json.dumps(dict_obj), enc)
+
+
+class WrongMessage(Exception):
+    pass

--- a/tests/spiders/sample1.py
+++ b/tests/spiders/sample1.py
@@ -4,3 +4,4 @@ import sys
 if __name__ == '__main__':
     status = sys.stdin.readline()
     sys.stdout.write('{"type": "log", "level": "debug", "message": "sample1.py working"}\n')
+    sys.stdout.flush()

--- a/tests/spiders/sample1.py
+++ b/tests/spiders/sample1.py
@@ -1,0 +1,6 @@
+#! /usr/bin/env python
+import sys
+
+if __name__ == '__main__':
+    status = sys.stdin.readline()
+    sys.stdout.write('{"type": "log", "level": "debug", "message": "sample1.py working"}\n')

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -103,16 +103,18 @@ class StreamingCommandTest(ProjectTest):
 
         self.assertIn('Usage', log)
 
-    def test_invalid_file(self):
-        p = self.proc('streaming', 'file_not_found.123')
-        log = to_native_str(p.stderr.read())
-
-        self.assertIn('File not found: file_not_found.123', log)
-
     def test_streaming(self):
         path = os.path.abspath(os.path.dirname(__file__))
         test1 = os.path.join(path, 'spiders', 'sample1.py')
         p = self.proc('streaming', test1)
+        log = to_native_str(p.stderr.read())
+
+        self.assertIn('sample1.py working', log)
+
+    def test_streaming_args(self):
+        path = os.path.abspath(os.path.dirname(__file__))
+        test1 = os.path.join(path, 'spiders', 'sample1.py')
+        p = self.proc('streaming', 'python', '-a', test1)
         log = to_native_str(p.stderr.read())
 
         self.assertIn('sample1.py working', log)

--- a/tests/test_communication/test_map.py
+++ b/tests/test_communication/test_map.py
@@ -1,0 +1,26 @@
+from twisted.trial import unittest
+
+from scrapy_streaming.communication.map import _extract_fields
+
+
+class CommunicationMapTest(unittest.TestCase):
+
+    def test_extract_field(self):
+        class Test(object):
+            a = 'a'
+            b = 2
+            c = {'a': 'b'}
+            d = [1, 2, 3]
+            e = 2.5
+            f = None
+
+        fields = ['a', 'b', 'c', 'd', 'e', 'f']
+        expected = {
+            'a': 'a',
+            'b': 2,
+            'c': {'a': 'b'},
+            'd': [1, 2, 3],
+            'e': 2.5,
+            'f': None
+        }
+        self.assertDictEqual(_extract_fields(Test(), fields), expected)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,7 +3,7 @@ import os
 from tests.test_commands import ProjectTest
 
 
-from scrapy_streaming.utils import get_project_root
+from scrapy_streaming.utils import get_project_root, dict_serialize
 
 
 class UtilsTest(ProjectTest):
@@ -14,3 +14,7 @@ class UtilsTest(ProjectTest):
     def test_get_project_default(self):
         os.chdir('../')
         self.assertRaises(Exception, get_project_root)
+
+    def test_dict_serialize(self):
+        d = {'a': 'b'}
+        self.assertEqual(dict_serialize(d), b'{"a": "b"}')


### PR DESCRIPTION
## PR Overview
### Commands

In this PR we have the `crawl` and `streaming` commands. 

`crawl` works as in scrapy. Inside project, it first tries to load a scrapy spider, and then if not found, try to load an external spider.
`streaming` commands is used to run external spiders without creating a project, using `streaming path_of_command` or `streaming path -a arg1,arg2 -a extra_arg`
### Communication

There is an initial work in the streaming core. Right now it's possible to connect with an external process, and I've done some work in the [communication layer](https://github.com/scrapy-plugins/scrapy-streaming/compare/master...aron-bordin:streaming?expand=1#diff-a6c80e15a4340b82052c1a50b0d5398dR9) 

These communication layers are not yet tested, because they are under development (work of the next week) and may be modified. 
### LineProcessProtocol

I've implemented this class to buffer the incoming data and just process it after receiving a entire line (message). 
I've thrown some `MessageError` in this class and in the `CommunicationMap`. These exception is being used to grab problems in the json format provided by the external spider.
