### PR TITLE
fix travis error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from setuptools import setup
+from setuptools import setup, find_packages
 
 setup(
     name='scrapy-streaming',
@@ -7,7 +7,7 @@ setup(
     url='https://github.com/scrapy-plugins/scrapy-streaming',
     description='Develop Spiders using any Programming Language',
     author='Scrapy developers',
-    packages=['scrapy_streaming'],
+    packages=find_packages(exclude=('tests', 'tests.*')),
     requires=['scrapy'],
 
     entry_points={

--- a/tox.ini
+++ b/tox.ini
@@ -17,11 +17,5 @@ commands =
     pip install -e .
     py.test --doctest-modules --cov=scrapy_streaming {posargs:scrapy_streaming tests}
 
-[testenv:py33]
-basepython = python3.3
-
-[testenv:py34]
-basepython = python3.4
-
 [testenv:py35]
 basepython = python3.5


### PR DESCRIPTION
in the last commits, travis is not running correctly because tox is not installing scrapystreaming completely.

This commit fixes this issue using find_packages in the setup.py

cc: @eLRuLL 
